### PR TITLE
(fix) add white as a color to tailwind config theme

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,7 @@ export default {
       "grey-light": "#EFEDED",
       "grey-dark": "#323232",
       "black": "#000000",
+      "white": "#FFFFFF",
     },
     fontFamily: {
       sans: ["Graphik", "sans-serif"],


### PR DESCRIPTION
White is used in our Figma designs extensively
https://www.figma.com/design/Y8ArOLdKsZFL2NgDVv4xj0/CS178A-Project and is used on the project but it's not being processed since it's not added to the theme.