### PR TITLE
(feat) make header better

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -6,7 +6,6 @@ import * as $_404 from "./routes/_404.tsx";
 import * as $_app from "./routes/_app.tsx";
 import * as $api_customClaims_getUserClaims from "./routes/api/customClaims/getUserClaims.ts";
 import * as $api_customClaims_setUserClaims from "./routes/api/customClaims/setUserClaims.ts";
-import * as $api_firebase from "./routes/api/firebase.ts";
 import * as $api_firebaseAdmin from "./routes/api/firebaseAdmin.ts";
 import * as $api_joke from "./routes/api/joke.ts";
 import * as $api_login_verifyIdToken from "./routes/api/login/verifyIdToken.ts";
@@ -33,7 +32,6 @@ const manifest = {
       $api_customClaims_getUserClaims,
     "./routes/api/customClaims/setUserClaims.ts":
       $api_customClaims_setUserClaims,
-    "./routes/api/firebase.ts": $api_firebase,
     "./routes/api/firebaseAdmin.ts": $api_firebaseAdmin,
     "./routes/api/joke.ts": $api_joke,
     "./routes/api/login/verifyIdToken.ts": $api_login_verifyIdToken,

--- a/islands/UsernameHeader.tsx
+++ b/islands/UsernameHeader.tsx
@@ -28,12 +28,14 @@ export default function UsernameHeader() {
     return (
       <div className="flex gap-2">
         <button
+          type="button"
           onClick={() => (globalThis.location.href = "/login")}
           className="bg-blue text-white rounded-md px-4 py-2 text-sm font-medium"
         >
           Log In
         </button>
         <button
+          type="button"
           onClick={() => (globalThis.location.href = "/signup")}
           className="bg-yellow text-white rounded-md px-4 py-2 text-sm font-medium"
         >
@@ -64,6 +66,7 @@ export default function UsernameHeader() {
             User Settings
           </button>
           <button
+            type="button"
             onClick={handleLogout}
             className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-grey-light"
           >

--- a/islands/UsernameHeader.tsx
+++ b/islands/UsernameHeader.tsx
@@ -12,14 +12,14 @@ export default function UsernameHeader() {
   const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+    const unsubscribe = onAuthStateChanged(auth, (firebaseUser: FirebaseUser | null) => {
       setUser(firebaseUser);
     });
     return () => unsubscribe();
   }, []);
 
   function handleLogout() {
-    signOut(auth).catch((err) => {
+    signOut(auth).catch((err: unknown) => {
       console.error("Sign out error:", err);
     });
   }

--- a/islands/UsernameHeader.tsx
+++ b/islands/UsernameHeader.tsx
@@ -60,6 +60,7 @@ export default function UsernameHeader() {
       {menuOpen && (
         <div className="absolute top-full right-0 bg-white border rounded-md shadow-md w-48 py-2 z-50">
           <button
+            type="button"
             onClick={() => (globalThis.location.href = "/settings")}
             className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-grey-light"
           >

--- a/islands/UsernameHeader.tsx
+++ b/islands/UsernameHeader.tsx
@@ -1,28 +1,76 @@
 "use client";
-import { onAuthStateChanged } from "firebase/auth";
-import { auth } from "../utils/firebase.ts";
 import { useEffect, useState } from "preact/hooks";
+import { onAuthStateChanged, signOut } from "firebase/auth";
+import { auth } from "../utils/firebase.ts";
 
 type FirebaseUser = {
   displayName?: string | null;
 };
 
 export default function UsernameHeader() {
-  const [username, setUsername] = useState("Guest");
+  const [user, setUser] = useState<FirebaseUser | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(
-      auth,
-      (user: FirebaseUser | null) => {
-        if (user) {
-          setUsername(user.displayName ?? "Guest");
-        } else {
-          setUsername("Guest");
-        }
-      },
-    );
+    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+      setUser(firebaseUser);
+    });
     return () => unsubscribe();
   }, []);
 
-  return <div className="text-gray-800 font-medium">{username}</div>;
+  function handleLogout() {
+    signOut(auth).catch((err) => {
+      console.error("Sign out error:", err);
+    });
+  }
+
+  if (!user) {
+    return (
+      <div className="flex gap-2">
+        <button
+          onClick={() => (globalThis.location.href = "/login")}
+          className="bg-blue text-white rounded-md px-4 py-2 text-sm font-medium"
+        >
+          Log In
+        </button>
+        <button
+          onClick={() => (globalThis.location.href = "/signup")}
+          className="bg-yellow text-white rounded-md px-4 py-2 text-sm font-medium"
+        >
+          Sign Up
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative inline-block"
+      onMouseEnter={() => setMenuOpen(true)}
+      onMouseLeave={() => setMenuOpen(false)}
+    >
+      <button
+        type="button"
+        className="text-gray-800 font-medium cursor-pointer bg-white px-4 py-2 rounded-md"
+      >
+        {user.displayName ?? "Guest"}
+      </button>
+      {menuOpen && (
+        <div className="absolute top-full right-0 bg-white border rounded-md shadow-md w-48 py-2 z-50">
+          <button
+            onClick={() => (globalThis.location.href = "/settings")}
+            className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-grey-light"
+          >
+            User Settings
+          </button>
+          <button
+            onClick={handleLogout}
+            className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-grey-light"
+          >
+            Log Out
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/islands/UsernameHeader.tsx
+++ b/islands/UsernameHeader.tsx
@@ -12,9 +12,12 @@ export default function UsernameHeader() {
   const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (firebaseUser: FirebaseUser | null) => {
-      setUser(firebaseUser);
-    });
+    const unsubscribe = onAuthStateChanged(
+      auth,
+      (firebaseUser: FirebaseUser | null) => {
+        setUser(firebaseUser);
+      },
+    );
     return () => unsubscribe();
   }, []);
 

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,4 +1,5 @@
 import { Head } from "$fresh/runtime.ts";
+import UsernameHeader from "../islands/UsernameHeader.tsx"; // Adjust the path as needed
 
 export default function Home() {
   return (
@@ -10,7 +11,6 @@ export default function Home() {
         />
       </Head>
       <div class="px-4 py-8 w-screen h-screen bg-grey-light flex flex-col font-oswald">
-        {/* Header */}
         <div className="flex justify-between items-center w-full px-8">
           <a href="/">
             <div className="flex text-2xl font-bold">
@@ -18,27 +18,11 @@ export default function Home() {
               <h1 className="text-blue">Network</h1>
             </div>
           </a>
-          <div className="flex gap-4">
-            <a href="/login">
-              <button
-                type="button"
-                className="px-4 py-2 bg-blue text-white rounded-md text-sm font-medium"
-              >
-                Login
-              </button>
-            </a>
-            <a href="/signup">
-              <button
-                type="button"
-                className="px-4 py-2 bg-yellow text-white rounded-md text-sm font-medium"
-              >
-                Sign Up
-              </button>
-            </a>
+          <div className="!font-normal">
+            <UsernameHeader />
           </div>
         </div>
 
-        {/* Main Content */}
         <main class="flex flex-col items-center flex-grow mt-8">
           <div class="max-w-screen-md flex flex-col items-center">
             <div class="flex flex-row text-4xl font-bold text-yellow">

--- a/routes/login/index.tsx
+++ b/routes/login/index.tsx
@@ -2,17 +2,16 @@
 import { Head } from "$fresh/runtime.ts";
 import GoogleSignIn from "../../islands/GoogleSignIn.tsx";
 import BusinessSignInForm from "../../islands/BusinessSignInForm.tsx";
+import UsernameHeader from "../../islands/UsernameHeader.tsx";
 
 export default function LoginPage() {
   return (
     <>
       <Head>
-        {/* Import Oswald font */}
         <link
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;700&display=swap"
         />
-        {/* Include the Google button CSS */}
         <style>
           {`
           .gsi-material-button {
@@ -46,14 +45,12 @@ export default function LoginPage() {
             max-width: 400px;
             min-width: min-content;
           }
-          
           .gsi-material-button .gsi-material-button-icon {
             height: 20px;
             margin-right: 12px;
             min-width: 20px;
             width: 20px;
           }
-          
           .gsi-material-button .gsi-material-button-content-wrapper {
             -webkit-align-items: center;
             align-items: center;
@@ -67,7 +64,6 @@ export default function LoginPage() {
             position: relative;
             width: 100%;
           }
-          
           .gsi-material-button .gsi-material-button-contents {
             -webkit-flex-grow: 1;
             flex-grow: 1;
@@ -77,7 +73,6 @@ export default function LoginPage() {
             text-overflow: ellipsis;
             vertical-align: top;
           }
-          
           .gsi-material-button .gsi-material-button-state {
             -webkit-transition: opacity .218s;
             transition: opacity .218s;
@@ -88,32 +83,26 @@ export default function LoginPage() {
             right: 0;
             top: 0;
           }
-          
           .gsi-material-button:disabled {
             cursor: default;
             background-color: #ffffff61;
             border-color: #1f1f1f1f;
           }
-          
           .gsi-material-button:disabled .gsi-material-button-contents {
             opacity: 38%;
           }
-          
           .gsi-material-button:disabled .gsi-material-button-icon {
             opacity: 38%;
           }
-          
           .gsi-material-button:not(:disabled):active .gsi-material-button-state, 
           .gsi-material-button:not(:disabled):focus .gsi-material-button-state {
             background-color: #303030;
             opacity: 12%;
           }
-          
           .gsi-material-button:not(:disabled):hover {
             -webkit-box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
             box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
           }
-          
           .gsi-material-button:not(:disabled):hover .gsi-material-button-state {
             background-color: #303030;
             opacity: 8%;
@@ -128,8 +117,8 @@ export default function LoginPage() {
           `}
         </style>
       </Head>
+
       <div className="font-oswald px-4 py-8 w-screen h-screen bg-grey-light flex flex-col">
-        {/* Header */}
         <div className="flex justify-between items-center w-full px-8">
           <a href="/">
             <div className="flex text-2xl font-bold">
@@ -137,25 +126,10 @@ export default function LoginPage() {
               <h1 className="text-blue">Network</h1>
             </div>
           </a>
-          <div className="flex gap-4">
-            <a
-              href="/login"
-              className="px-4 py-2 bg-blue text-white rounded-md text-sm font-medium"
-            >
-              Login
-            </a>
-            <a
-              href="/signup"
-              className="px-4 py-2 bg-yellow text-white rounded-md text-sm font-medium"
-            >
-              Sign Up
-            </a>
-          </div>
+          <UsernameHeader />
         </div>
 
-        {/* Main Content */}
         <div className="flex flex-col justify-center items-center gap-8 mt-8 px-8">
-          {/* Student Sign In */}
           <div className="w-full max-w-md p-6 bg-white shadow-md rounded-md">
             <h2 className="text-xl font-bold mb-6 text-center">
               Student Sign In
@@ -163,7 +137,6 @@ export default function LoginPage() {
             <GoogleSignIn />
           </div>
 
-          {/* Business Sign In */}
           <div className="w-full max-w-md p-6 bg-white shadow-md rounded-md">
             <h2 className="text-xl font-bold mb-6 text-center">
               Business Sign In

--- a/routes/signup/index.tsx
+++ b/routes/signup/index.tsx
@@ -1,19 +1,17 @@
 "use client";
 import { Head } from "$fresh/runtime.ts";
 import GoogleSignUp from "../../islands/GoogleSignUp.tsx";
-import HeaderSignUpButton from "../../islands/HeaderSignUpButton.tsx";
+import UsernameHeader from "../../islands/UsernameHeader.tsx";
 import BusinessSignUpForm from "../../islands/BusinessSignUpForm.tsx";
 
 export default function SignUpPage() {
   return (
     <>
       <Head>
-        {/* Import Oswald font */}
         <link
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;700&display=swap"
         />
-        {/* Include the Google button CSS */}
         <style>
           {`
           .gsi-material-button {
@@ -47,14 +45,12 @@ export default function SignUpPage() {
             max-width: 400px;
             min-width: min-content;
           }
-          
           .gsi-material-button .gsi-material-button-icon {
             height: 20px;
             margin-right: 12px;
             min-width: 20px;
             width: 20px;
           }
-          
           .gsi-material-button .gsi-material-button-content-wrapper {
             -webkit-align-items: center;
             align-items: center;
@@ -68,7 +64,6 @@ export default function SignUpPage() {
             position: relative;
             width: 100%;
           }
-          
           .gsi-material-button .gsi-material-button-contents {
             -webkit-flex-grow: 1;
             flex-grow: 1;
@@ -78,7 +73,6 @@ export default function SignUpPage() {
             text-overflow: ellipsis;
             vertical-align: top;
           }
-          
           .gsi-material-button .gsi-material-button-state {
             -webkit-transition: opacity 0.218s;
             transition: opacity 0.218s;
@@ -89,32 +83,26 @@ export default function SignUpPage() {
             right: 0;
             top: 0;
           }
-          
           .gsi-material-button:disabled {
             cursor: default;
             background-color: #ffffff61;
             border-color: #1f1f1f1f;
           }
-          
           .gsi-material-button:disabled .gsi-material-button-contents {
             opacity: 38%;
           }
-          
           .gsi-material-button:disabled .gsi-material-button-icon {
             opacity: 38%;
           }
-          
-          .gsi-material-button:not(:disabled):active .gsi-material-button-state, 
+          .gsi-material-button:not(:disabled):active .gsi-material-button-state,
           .gsi-material-button:not(:disabled):focus .gsi-material-button-state {
             background-color: #303030;
             opacity: 12%;
           }
-          
           .gsi-material-button:not(:disabled):hover {
             -webkit-box-shadow: 0 1px 2px 0 rgba(60, 64, 67, 0.30), 0 1px 3px 1px rgba(60, 64, 67, 0.15);
             box-shadow: 0 1px 2px 0 rgba(60, 64, 67, 0.30), 0 1px 3px 1px rgba(60, 64, 67, 0.15);
           }
-          
           .gsi-material-button:not(:disabled):hover .gsi-material-button-state {
             background-color: #303030;
             opacity: 8%;
@@ -129,8 +117,8 @@ export default function SignUpPage() {
           `}
         </style>
       </Head>
+
       <div className="font-oswald px-4 py-8 w-screen h-screen bg-grey-light flex flex-col">
-        {/* Header */}
         <div className="flex justify-between items-center w-full px-8">
           <a href="/">
             <div className="flex text-2xl font-bold">
@@ -138,23 +126,10 @@ export default function SignUpPage() {
               <h1 className="text-blue">Network</h1>
             </div>
           </a>
-          <div className="flex gap-4">
-            <a href="/login">
-              <button
-                type="submit"
-                className="px-4 py-2 bg-blue text-white rounded-md text-sm font-medium"
-              >
-                Login
-              </button>
-            </a>
-            {/* Header sign-up button rendered as an island */}
-            <HeaderSignUpButton />
-          </div>
+          <UsernameHeader />
         </div>
 
-        {/* Main Content */}
         <div className="flex flex-col justify-center items-center gap-8 mt-8 px-8">
-          {/* Student Sign Up */}
           <div className="w-full max-w-md p-6 bg-white shadow-md rounded-md">
             <h2 className="text-xl font-bold mb-6 text-center">
               Student Sign Up
@@ -162,7 +137,6 @@ export default function SignUpPage() {
             <GoogleSignUp />
           </div>
 
-          {/* Business Sign Up */}
           <div className="w-full max-w-md p-6 bg-white shadow-md rounded-md">
             <h2 className="text-xl font-bold mb-6 text-center">
               Business Sign Up


### PR DESCRIPTION
Improve the header and make it more interactive. Went above and beyond and added separate states for when a student or business is logged out the option to log in or sign up. At the very least if the student is logged in the username shows up automatically. The student or business can then hover over their username and have the option to actually log out or even change their personal settings. More options can be added as the application constantly is getting scaled up. By doing this we remove the need for individual Log In and Sign Up buttons on every page and everything can just use the "UsernameHeader" island. This also deprecates the "HeaderSignUpButton" island, (whose deprecation would be another PR). As well improves the overall consistency of the codebase as the Sign In button doesn't have its own island.